### PR TITLE
Execute role from readme and add to project

### DIFF
--- a/index.md
+++ b/index.md
@@ -63,5 +63,10 @@
 | scrum.pmo/sprints/sprint-3/task-1.3-devops-release-recovery.md | Sprint task | 2025-08-08 |
 | scrum.pmo/sprints/sprint-3/task-1.4-tester-e2e-tests.md | Sprint task | 2025-08-08 |
 | scrum.pmo/sprints/sprint-3/task-1.5-po-user-guide.md | Sprint task | 2025-08-08 |
+| scrum.pmo/roles/OntologyArchitect/process.md | Ontology Architect process | 2025-08-10 |
+| wiki/ontology/nouns.index.md | Ontology | 2025-08-10 |
+| wiki/ontology/verbs.index.md | Ontology | 2025-08-10 |
+| wiki/ontology/ambiguities.index.md | Ontology | 2025-08-10 |
+| wiki/ontology/ontology.status.md | Ontology | 2025-08-10 |
 
 *This index is auto-generated for recovery and onboarding. Update as new markdown files are added.*

--- a/recovery.md
+++ b/recovery.md
@@ -115,3 +115,18 @@
 
 **Next Steps:**
 - Proceed to QA review for Task 7, then mark Done upon approval.
+
+## 2025-08-10
+
+**Summary:**
+- Recovered from README and executed the Ontology Architect role.
+- Added role file `scrum.pmo/roles/OntologyArchitect/process.md`.
+- Created ontology files under `wiki/ontology/`: `nouns.index.md`, `verbs.index.md`, `ambiguities.index.md`, `ontology.status.md`.
+- Updated `index.md` to include ontology files and role.
+
+**Ontology Metrics:**
+- Nouns: 10; Verbs: 10; Ambiguities: 5.
+
+**Next Steps:**
+- Expand ontology indexes from broader repository scan and link terms back to source files.
+- Add automated link validation in pre-commit for ontology files.

--- a/scrum.pmo/roles/OntologyArchitect/process.md
+++ b/scrum.pmo/roles/OntologyArchitect/process.md
@@ -1,0 +1,47 @@
+# Ontology Architect — Process
+
+[Back to Roles](../)
+
+## Role Definition
+The Ontology Architect ensures conceptual clarity and semantic consistency across the project. This role maintains ontology indexes (nouns, verbs, ambiguities), enforces CMM Level 3 well-defined documentation with CMM Level 4 automated feedback loops, and preserves cross-reference integrity across markdown artifacts.
+
+## Responsibilities
+- Maintain ontology indexes under `wiki/ontology/`:
+  - `nouns.index.md`
+  - `verbs.index.md`
+  - `ambiguities.index.md`
+  - `ontology.status.md`
+- Enforce semantic consistency and resolve ambiguities across docs.
+- Keep cross-references updated; ensure links are valid.
+- Integrate CMM Level 4 iterative improvement via background agent work.
+- Provide metrics: counts of nouns, verbs, ambiguities, coverage.
+- Contribute to recovery by verifying ontology health on each recovery cycle.
+
+## Operating Procedure
+1. Recovery Hook
+   - Read `README.md` First Principles and Recovery steps.
+   - Verify ontology files exist and update `ontology.status.md` with counts and last run timestamp.
+   - Run a quick link review in the ontology files.
+2. Discovery & Indexing
+   - Scan markdown files in the repository (`*.md`).
+   - Update `nouns.index.md`, `verbs.index.md`, and `ambiguities.index.md` with terms discovered, grouping by domain when useful.
+   - Add cross-links to definitions or source files when available.
+3. Consistency & Ambiguity Resolution
+   - Identify overloaded or ambiguous terms and record them in `ambiguities.index.md` with clarifications.
+4. Documentation Updates
+   - Ensure `index.md` lists ontology files with last modified dates.
+   - Append a concise summary to `recovery.md` describing actions and next steps.
+5. Metrics & Reporting
+   - Update counts in `ontology.status.md` and summarize changes.
+6. Commit Policy
+   - Use commit messages of the form:
+     - `chore(ontology): [component] – [summary] – nouns:+N verbs:+V amb:+A`
+
+## Acceptance Criteria
+- Ontology files exist and are linked from `index.md`.
+- `ontology.status.md` shows current counts and timestamp.
+- No broken links in ontology files.
+- Recovery log updated with a summary of ontology maintenance.
+
+## References
+- Role intent and prior work inspiration: `scrum.pmo/project.journal/2025-08-10-1030/retro/answer.OntologyWeaver.md`


### PR DESCRIPTION
Add Ontology Architect role and initial ontology files to improve conceptual clarity and semantic consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b484528-874b-4db3-b09f-5052833f40c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b484528-874b-4db3-b09f-5052833f40c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

