### PR TITLE
Automate license header and backlink enforcement

### DIFF
--- a/.github/chatmodes/ScrumMaster2QA.chatmode.md
+++ b/.github/chatmodes/ScrumMaster2QA.chatmode.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 ---
 description: 'Description of the custom chat mode.'
 tools: []

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+# Copyright (c) 2025 The Web4Articles Authors
+# Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+# Backlinks: /LICENSE , /AI-GPL.md
+# Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
+name: License Headers
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  check-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Check license headers
+        run: node --loader ts-node/esm ./src/ts/layer1/TSsh.ts LicenseTool check

--- a/AI-GPL.md
+++ b/AI-GPL.md
@@ -1,0 +1,56 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
+# Web4Articles AI-GPL Addendum (Draft – Do Your Research)
+
+This document extends the GNU Affero General Public License v3.0 (AGPL-3.0) for the Web4Articles project to address AI-assisted usage and to clarify that certain process artifacts are treated as source code.
+
+- Canonical AGPLv3 text: see `LICENSE` in this repository.
+- This addendum is provided as a research draft (DYR). It is not legal advice. Consult a qualified attorney before relying on or publishing this text.
+
+## 1. Relationship to AGPLv3
+
+- This Addendum ("AI-GPL") supplements and does not replace AGPLv3.
+- In case of conflict, the most restrictive copyleft interpretation consistent with AGPLv3 applies, unless you hold a separate dual-license agreement with the copyright holders.
+
+## 2. Scope of “Source Code” and “Covered Work”
+
+- For the purposes of this project, the following are considered part of the "preferred form for making modifications" and thus are "Source Code" under AGPLv3:
+  - All TypeScript, shell scripts, configuration, documentation, and example files in this repository.
+  - All `scrum.pmo` roles, processes, templates, SOPs, sprint plans, task definitions, and other process artifacts. These are treated as programmatic assets that directly govern and produce the project’s behavior.
+
+## 3. AI-Assisted Usage Triggers Copyleft
+
+- If you use any portion of this repository (including `scrum.pmo` files) to train, prompt, instruct, or otherwise direct an AI system or agent to produce outputs that replicate, implement, or substantially derive from this project, those outputs are a "Covered Work" under AI-GPL and must be licensed under AGPLv3 plus this AI-GPL Addendum, unless you have obtained a dual-license.
+- "Substantially derive" includes outputs that encode or implement the same design, processes, roles, or logic such that the outputs are reasonably substitutable for the originals.
+
+## 4. Network Use and Service Provision
+
+- If a network service or AI agent exposes functionality that is materially based on this repository (including process artifacts), the complete corresponding source of the modified work, including prompts, policies, and orchestration logic, must be made available under AGPLv3 plus this Addendum to the users of that service.
+
+## 5. Dual Licensing
+
+- Commercial dual-licensing is available. Contact the maintainers for terms that allow proprietary use without the copyleft obligations of this Addendum.
+
+## 6. Attribution and Backlinks
+
+- All files in this repository must include a license header or frontmatter linking to:
+  - AGPLv3: `./LICENSE`
+  - AI-GPL Addendum (this file): `./AI-GPL.md`
+
+## 7. Compatibility and SPDX
+
+- SPDX: use `AGPL-3.0-only` or `AGPL-3.0-or-later` for the base license. The AI-GPL Addendum has no official SPDX identifier; note it as `AI-GPL-Addendum` in headers.
+
+## 8. No Warranty
+
+- As with AGPLv3, this Addendum is provided “AS IS”, without warranty of any kind.
+
+---
+
+By contributing to or using this repository, you agree to comply with AGPLv3 and this AI-GPL Addendum, unless a separate dual-license has been executed.

--- a/COMMIT_PUSH_POINT.md
+++ b/COMMIT_PUSH_POINT.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 # Commit & Push Point: Modern TypeScript, ES Modules, and Robust CLI Completion
 
 ## Summary

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Index](./index.md)
 
 # Web4Articles
@@ -134,3 +142,13 @@ src/sh/obash 'tssh TSsh help'
   - Type the value; press Space or Enter to commit and advance
   - When all values are provided, the method executes immediately
   - `q`/`Esc` quits; navigation is disabled while entering a parameter value
+
+### License enforcement (Sprint 10)
+
+- Base license: AGPL-3.0 (see `LICENSE`)
+- Addendum: AI-GPL (see `AI-GPL.md`) — DYR draft clarifying AI usage and `scrum.pmo` copyleft
+- Tooling:
+  - Check: `node --loader ts-node/esm src/ts/layer1/TSsh.ts LicenseTool check`
+  - Apply: `node --loader ts-node/esm src/ts/layer1/TSsh.ts LicenseTool apply`
+- CI: GitHub Action `license-headers.yml` blocks PRs that add files without headers.
+- Dual licensing available; contact maintainers.

--- a/branch-overview.md
+++ b/branch-overview.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Index](./index.md)
 
 # Branch Overview

--- a/docs/domain/SimpleTaskStateMachine.md
+++ b/docs/domain/SimpleTaskStateMachine.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # SimpleTaskStateMachine (Domain Model)

--- a/docs/domain/TaskStateMachine.md
+++ b/docs/domain/TaskStateMachine.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # TaskStateMachine (Domain Model)

--- a/docs/domain/daily.md
+++ b/docs/domain/daily.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # Daily Log (Migrated)

--- a/docs/domain/planning.md
+++ b/docs/domain/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # Planning Log (Migrated)

--- a/docs/process-migration-log.md
+++ b/docs/process-migration-log.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # 2025-08-03 (DevContainer & Task File Migration)

--- a/docs/puml/tssh-architecture-structure.puml
+++ b/docs/puml/tssh-architecture-structure.puml
@@ -1,3 +1,9 @@
+' SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+' Copyright (c) 2025 The Web4Articles Authors
+' Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+' Backlinks: /LICENSE , /AI-GPL.md
+' Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 @startuml tssh-architecture-structure
 ' tssh CLI Wrapper and Backend Structure (Component/Package Diagram)
 

--- a/docs/puml/tssh-architecture.puml
+++ b/docs/puml/tssh-architecture.puml
@@ -1,3 +1,9 @@
+' SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+' Copyright (c) 2025 The Web4Articles Authors
+' Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+' Backlinks: /LICENSE , /AI-GPL.md
+' Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 @startuml 
 ' tssh CLI Wrapper and Backend Architecture
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # Web4Articles Technology Stack & Testing

--- a/docs/updown-removal-fix-log.md
+++ b/docs/updown-removal-fix-log.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Docs](../)
 
 # UpDown Reference Removal Fix Log

--- a/index.md
+++ b/index.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Index](./index.md)
 
 # Web4Articles Markdown File Index (2025-08-06)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@types/node": "^24.1.0",
         "execa": "^9.6.0",
         "ts-node": "^10.9.2",
+        "typescript": "^5.5.4",
         "vitest": "^3.2.4"
       }
     },
@@ -1762,7 +1763,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
     "@types/node": "^24.1.0",
     "execa": "^9.6.0",
     "ts-node": "^10.9.2",
+    "typescript": "^5.5.4",
     "vitest": "^3.2.4"
   },
   "scripts": {
     "test": "vitest run",
-    "tsranger": "node --loader ts-node/esm ./src/ts/layer4/TSRanger.ts"
+    "tsranger": "node --loader ts-node/esm ./src/ts/layer4/TSRanger.ts",
+    "license:check": "node --loader ts-node/esm ./src/ts/layer1/TSsh.ts LicenseTool check",
+    "license:apply": "node --loader ts-node/esm ./src/ts/layer1/TSsh.ts LicenseTool apply"
   }
 }

--- a/qa-feedback-log.md
+++ b/qa-feedback-log.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Index](./index.md)
 
 # QA Feedback Log (2025-08-06)

--- a/recovery.md
+++ b/recovery.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 # Recovery Log
 
 ## 2025-08-11

--- a/scrum.pmo/project.journal/2025-08-10-0854/project.state.md
+++ b/scrum.pmo/project.journal/2025-08-10-0854/project.state.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Project Journal](../)
 
 # Project State — 2025-08-10 08:54 UTC

--- a/scrum.pmo/project.journal/2025-08-10-1030/project.state.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/project.state.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Project Journal](../)
 
 # Project State — 2025-08-10 10:30 UTC

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/01.retro-instructions.what.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/01.retro-instructions.what.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Journal Entry](../)
 
 # Project Retrospective — Instructions

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/02.retro-status.overview.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/02.retro-status.overview.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro](../)
 
 # Retro Status — Overview

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/04.agent-interview.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/04.agent-interview.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./01.retro-instructions.what.md)
 
 # Agent Interview Prompt (copy into each agent)

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/99.retro-measures.action.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/99.retro-measures.action.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro](../)
 
 # Retro Measures — Action List

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/agent-interview.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/agent-interview.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./01.retro-instructions.what.md)
 
 # Agent Interview Prompt

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.BackendMaestro-1.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.BackendMaestro-1.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Journal Entry](../)
 
 # Retrospective — BackendMaestro-1

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.DevContainer-Cartographer-1.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.DevContainer-Cartographer-1.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 # Agent Retrospective — DevContainer-Cartographer-1
 
 Repository: `Web4Articles`

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.DevcontainerCartographer.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.DevcontainerCartographer.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./01.retro-instructions.what.md)
 
 # Retro Agent Answer — DevcontainerCartographer (GPT-5 ScrumMaster)

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.OntologyWeaver.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.OntologyWeaver.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Journal Entry](../)
 
 # Project Retrospective — OntologyWeaver

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.PromptlineConductor.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.PromptlineConductor.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./01.retro-instructions.what.md)
 
 # Retro Agent Answer — PromptlineConductor (GPT-5 ScrumMaster)

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.ResearchArchitect.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.ResearchArchitect.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./01.retro-instructions.what.md)
 
 # ResearchArchitect Retrospective — 2025-08-10

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.assistant.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.assistant.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./retro-instructions.md)
 
 # Assistant Retrospective — 2025-08-10

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.broken.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.broken.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Journal Entry](../)
 
 # Project Retrospective — GPT-5

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.gpt-5.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.gpt-5.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./retro-instructions.md)
 
 # GPT-5 Retrospective — 2025-08-10

--- a/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.retro-agent.md
+++ b/scrum.pmo/project.journal/2025-08-10-1030/retro/answer.retro-agent.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Retro Instructions](./retro-instructions.md)
 
 # Retro Agent Answer — retro-agent (GPT-5 ScrumMaster)

--- a/scrum.pmo/project.journal/2025-08-11-0955/project.state.md
+++ b/scrum.pmo/project.journal/2025-08-11-0955/project.state.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Project Journal](../)
 
 # Project State — 2025-08-11 09:55 UTC

--- a/scrum.pmo/roles/Architect/process.md
+++ b/scrum.pmo/roles/Architect/process.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Roles](../)
 
 # AI Feedback Processing Protocol

--- a/scrum.pmo/roles/DevOps/process.md
+++ b/scrum.pmo/roles/DevOps/process.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Roles](../)
 
 # DevOps First Principles & Learnings (Canonical)

--- a/scrum.pmo/roles/Developer/process.md
+++ b/scrum.pmo/roles/Developer/process.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Roles](../)
 
 # AI Feedback Processing Protocol

--- a/scrum.pmo/roles/PO/process.md
+++ b/scrum.pmo/roles/PO/process.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Roles](../)
 
 # Product Owner (PO) Role Process

--- a/scrum.pmo/roles/PO/sprint-n-template/planning.md
+++ b/scrum.pmo/roles/PO/sprint-n-template/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 # Sprint n Planning Template
 
 ## Sprint Goal

--- a/scrum.pmo/roles/PO/sprint-n-template/task-0-example-task.md
+++ b/scrum.pmo/roles/PO/sprint-n-template/task-0-example-task.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 
 [Back to Planning Sprint n](./planning.md)
 

--- a/scrum.pmo/roles/PO/sprint-n-template/task-0.1-example-subtask.md
+++ b/scrum.pmo/roles/PO/sprint-n-template/task-0.1-example-subtask.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning Sprint n](./planning.md) | [Back to Task 0](./task-0-example-task.md)
 
 # Task 0.1: Example Subtask

--- a/scrum.pmo/roles/ScrumMaster/process.md
+++ b/scrum.pmo/roles/ScrumMaster/process.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Roles](../)
 
 

--- a/scrum.pmo/roles/Tester/process.md
+++ b/scrum.pmo/roles/Tester/process.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Roles](../)
 
 # AI Feedback Processing Protocol

--- a/scrum.pmo/sprints/initialization.md
+++ b/scrum.pmo/sprints/initialization.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 # Project Initialization Process
 
 This document describes the steps taken to initialize the Web4Articles project, including the setup of SCRUM management, documentation, and the project wiki.

--- a/scrum.pmo/sprints/sprint-0/planning.md
+++ b/scrum.pmo/sprints/sprint-0/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprints](../)
 
 # Sprint 0 Planning

--- a/scrum.pmo/sprints/sprint-0/process.ambiguity.md
+++ b/scrum.pmo/sprints/sprint-0/process.ambiguity.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 - [x] MAIN vs SUBTASK naming and numbering

--- a/scrum.pmo/sprints/sprint-0/requiremnents.md
+++ b/scrum.pmo/sprints/sprint-0/requiremnents.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Sprint 0 — Requirements distilled from QA feedback

--- a/scrum.pmo/sprints/sprint-0/task-0-create-sprint-0-planning-file.md
+++ b/scrum.pmo/sprints/sprint-0/task-0-create-sprint-0-planning-file.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 0: Create Sprint 0 Planning File

--- a/scrum.pmo/sprints/sprint-0/task-1-create-scrum-structure.md
+++ b/scrum.pmo/sprints/sprint-0/task-1-create-scrum-structure.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-0/task-2-setup-wiki-submodule.md
+++ b/scrum.pmo/sprints/sprint-0/task-2-setup-wiki-submodule.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-0/task-3-create-ontology-page.md
+++ b/scrum.pmo/sprints/sprint-0/task-3-create-ontology-page.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-0/task-4-document-role-responsibilities.md
+++ b/scrum.pmo/sprints/sprint-0/task-4-document-role-responsibilities.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-0/task-5-template-new-subproject.md
+++ b/scrum.pmo/sprints/sprint-0/task-5-template-new-subproject.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-0/task-5.1-architect-puml-spec.md
+++ b/scrum.pmo/sprints/sprint-0/task-5.1-architect-puml-spec.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprint 0 Planning](./planning.md) | [Back to Main Task 5](./task-5-template-new-subproject.md)
 
 # Task 5.1: Architect - PlantUML Specification

--- a/scrum.pmo/sprints/sprint-0/task-5.2-developer-implementation.md
+++ b/scrum.pmo/sprints/sprint-0/task-5.2-developer-implementation.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # [Back to Sprint 0 Planning](./planning.md)

--- a/scrum.pmo/sprints/sprint-0/task-5.3-developer-testing.md
+++ b/scrum.pmo/sprints/sprint-0/task-5.3-developer-testing.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # [Back to Sprint 0 Planning](./planning.md)

--- a/scrum.pmo/sprints/sprint-0/task-5.4-developer-documentation.md
+++ b/scrum.pmo/sprints/sprint-0/task-5.4-developer-documentation.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # [Back to Sprint 0 Planning](./planning.md)

--- a/scrum.pmo/sprints/sprint-0/task-5.5-po-planning-acceptance.md
+++ b/scrum.pmo/sprints/sprint-0/task-5.5-po-planning-acceptance.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprint 0 Planning](./planning.md) | [Back to Main Task 5](./task-5-template-new-subproject.md)
 
 # Task 5.5: PO - Planning & Acceptance

--- a/scrum.pmo/sprints/sprint-0/task-5.6-scrummaster-process-verification.md
+++ b/scrum.pmo/sprints/sprint-0/task-5.6-scrummaster-process-verification.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # [Back to Sprint 0 Planning](./planning.md)

--- a/scrum.pmo/sprints/sprint-0/task-6-devcontainer-requirements.md
+++ b/scrum.pmo/sprints/sprint-0/task-6-devcontainer-requirements.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 6: DevContainer Requirements

--- a/scrum.pmo/sprints/sprint-1/planning.md
+++ b/scrum.pmo/sprints/sprint-1/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprints](../)
 
 # Sprint 1 Planning

--- a/scrum.pmo/sprints/sprint-1/task-1-tssh-wrapper.md
+++ b/scrum.pmo/sprints/sprint-1/task-1-tssh-wrapper.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-1/task-1.0-architect-tssh-spec.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.0-architect-tssh-spec.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-1/task-1.1-developer-tssh-wrapper.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.1-developer-tssh-wrapper.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.1: Developer - Implement tssh shell wrapper

--- a/scrum.pmo/sprints/sprint-1/task-1.1.5-tester-tssh-testcases.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.1.5-tester-tssh-testcases.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-1/task-1.2-developer-tssh-backend.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.2-developer-tssh-backend.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.2: Developer - Implement TSsh.ts backend

--- a/scrum.pmo/sprints/sprint-1/task-1.3-developer-tssh-completion.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.3-developer-tssh-completion.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.3: Developer - Implement Bash completion for tssh

--- a/scrum.pmo/sprints/sprint-1/task-1.4-po-document-tssh.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.4-po-document-tssh.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.4: PO - Document tssh approach

--- a/scrum.pmo/sprints/sprint-1/task-1.5-tester-completion-tests.md
+++ b/scrum.pmo/sprints/sprint-1/task-1.5-tester-completion-tests.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 

--- a/scrum.pmo/sprints/sprint-10/plan.md
+++ b/scrum.pmo/sprints/sprint-10/plan.md
@@ -1,0 +1,44 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
+# Sprint 10 Plan
+
+## Goal
+Establish an explicit AI-GPL addendum to AGPLv3, enforce license headers and backlinks across the repository with TypeScript tooling, and integrate automated checks into CI for new files.
+
+## User Stories
+- As a maintainer, I want a clear AI-GPL addendum so legal terms for AI use and process artifacts are unambiguous.
+- As a developer, I want a tool that adds and updates license headers format-aware for .ts/.md/.puml/etc., so all files carry copyleft backlinks.
+- As a CI gatekeeper, I want an automated check that fails PRs missing headers, so new files comply.
+- As a product owner, I want `scrum.pmo` artifacts treated as source under AI-GPL, so AI usage remains copyleft unless dual-licensed.
+
+## Scope & Deliverables
+- `AI-GPL.md` drafted with DYR notes, backlinks to AGPLv3.
+- `LicenseTool` TypeScript CLI (ESM, OOP) with `check` and `apply` methods.
+- Comment-aware headers for: ts, tsx, js, jsx, md, puml, plantuml, sh, yml, yaml.
+- GitHub Action workflow to run header check on push/PR.
+- Minimal unit tests for header insertion.
+
+## Tasks
+1. Draft `AI-GPL.md` addendum with copyleft clarifications and backlinks.
+2. Implement `LicenseTool` with file discovery, comment-style mapping, header builder, check/apply flows.
+3. Add vitest tests for key formats (.ts, .md, .puml).
+4. Create `.github/workflows/license-headers.yml` to enforce on CI.
+5. Run repo-wide `apply` and commit changes.
+6. Update contributor docs with usage instructions.
+
+## Acceptance Criteria
+- `AI-GPL.md` exists; links to `LICENSE` and vice versa via headers.
+- Running `node --loader ts-node/esm src/ts/layer1/TSsh.ts LicenseTool check` on a clean repo returns success.
+- New files without headers cause CI failure.
+- Headers include: SPDX line, copyright, copyleft/backlinks, AI-GPL note for `scrum.pmo`.
+
+## Definition of Done
+- CI green on main with header check enabled.
+- Tools documented in README or `scrum.pmo` notes.
+- All tracked file types in repo have headers applied.

--- a/scrum.pmo/sprints/sprint-2/planning.md
+++ b/scrum.pmo/sprints/sprint-2/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprints](../)
 
 # Sprint 2 Planning

--- a/scrum.pmo/sprints/sprint-2/requiremnents.md
+++ b/scrum.pmo/sprints/sprint-2/requiremnents.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # user requirements

--- a/scrum.pmo/sprints/sprint-2/task-1.1-architect-ranger-spec.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.1-architect-ranger-spec.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.1 — Architect: TS Ranger Shell Specification (role-specific)

--- a/scrum.pmo/sprints/sprint-2/task-1.2-developer-ranger-tui.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.2-developer-ranger-tui.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.2 — Developer: Interactive TUI (Core Navigation)

--- a/scrum.pmo/sprints/sprint-2/task-1.3-developer-completion-integration.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.3-developer-completion-integration.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.3 — Developer: Integrate TSCompletion for Live Suggestions

--- a/scrum.pmo/sprints/sprint-2/task-1.4-developer-execution-bridge.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.4-developer-execution-bridge.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.4 — Developer: Command Execution Bridge to DefaultCLI

--- a/scrum.pmo/sprints/sprint-2/task-1.5-tester-e2e-tests.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.5-tester-e2e-tests.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.5 — Tester: E2E Keyboard Navigation and Execution Tests

--- a/scrum.pmo/sprints/sprint-2/task-1.6-po-user-guide.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.6-po-user-guide.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.6 — PO: User Guide and Demo Scenarios

--- a/scrum.pmo/sprints/sprint-2/task-1.7-developer-refactor-tsranger.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.7-developer-refactor-tsranger.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.7: Developer - Refactor TSRanger to one class per TS file

--- a/scrum.pmo/sprints/sprint-2/task-1.8-developer-parameter-entry.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.8-developer-parameter-entry.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.8 — Developer: Sequential Parameter Entry and Auto-Execute

--- a/scrum.pmo/sprints/sprint-2/task-1.md
+++ b/scrum.pmo/sprints/sprint-2/task-1.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1 — Architect: TS Ranger Shell Specification

--- a/scrum.pmo/sprints/sprint-2/task-2.1-developer-footer-height-and-spacing.md
+++ b/scrum.pmo/sprints/sprint-2/task-2.1-developer-footer-height-and-spacing.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task2](./task-2.md)
 
 # Task 2.1: Developer — Footer height, spacing, and empty lines around command preview

--- a/scrum.pmo/sprints/sprint-2/task-2.2-developer-footer-and-color-preview.md
+++ b/scrum.pmo/sprints/sprint-2/task-2.2-developer-footer-and-color-preview.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 2.2 — Developer: Blue/White Key Usage Footer and Colorized Command Preview

--- a/scrum.pmo/sprints/sprint-2/task-2.3-developer-fix-selected-row-indentation.md
+++ b/scrum.pmo/sprints/sprint-2/task-2.3-developer-fix-selected-row-indentation.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 2.3: Developer — Fix selected row indentation across columns in TSRanger

--- a/scrum.pmo/sprints/sprint-2/task-2.md
+++ b/scrum.pmo/sprints/sprint-2/task-2.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning Sprint 2](./planning.md)
 
 # Task 2: Footer height/spacing and colorized command preview

--- a/scrum.pmo/sprints/sprint-2/task-3.1-developer-command-prompt-ps1.md
+++ b/scrum.pmo/sprints/sprint-2/task-3.1-developer-command-prompt-ps1.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 3](./task-3.md)
 
 # Task 3.1: Developer — Command prompt for preview using $PS1 (hostname user@pwd)

--- a/scrum.pmo/sprints/sprint-2/task-3.2-developer-prompt-spacing.md
+++ b/scrum.pmo/sprints/sprint-2/task-3.2-developer-prompt-spacing.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 3](./task-3.md)
 
 # Task 3.2 — Developer: Prompt spacing (exactly one empty line above command)

--- a/scrum.pmo/sprints/sprint-2/task-3.3-developer-prompt-colors.md
+++ b/scrum.pmo/sprints/sprint-2/task-3.3-developer-prompt-colors.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 3](./task-3.md)
 
 # Task 3.3 — Developer: Prompt colors (user cyan, root red, path yellow)

--- a/scrum.pmo/sprints/sprint-2/task-3.md
+++ b/scrum.pmo/sprints/sprint-2/task-3.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning Sprint 2](./planning.md)
 
 # Task 3: Command prompt from $PS1 or hostname user@pwd

--- a/scrum.pmo/sprints/sprint-2/task-4.1-architect-docs-spec.md
+++ b/scrum.pmo/sprints/sprint-2/task-4.1-architect-docs-spec.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 4](./task-4.md)
 
 # Task 4.1 — Architect: Documentation Column and Docstring Extraction Spec

--- a/scrum.pmo/sprints/sprint-2/task-4.2-developer-tscompletion-docs.md
+++ b/scrum.pmo/sprints/sprint-2/task-4.2-developer-tscompletion-docs.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 4](./task-4.md)
 
 # Task 4.2 — Developer: Extend TSCompletion to expose TypeScript JSDoc for Class/Method/Params

--- a/scrum.pmo/sprints/sprint-2/task-4.3-developer-docs-column.md
+++ b/scrum.pmo/sprints/sprint-2/task-4.3-developer-docs-column.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 4](./task-4.md)
 
 # Task 4.3 — Developer: Replace Preview grid column with Docs (selected element docstring)

--- a/scrum.pmo/sprints/sprint-2/task-4.4-tester-e2e-docs.md
+++ b/scrum.pmo/sprints/sprint-2/task-4.4-tester-e2e-docs.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 4](./task-4.md)
 
 # Task 4.4 — Tester: E2E scripted checks for Docs column

--- a/scrum.pmo/sprints/sprint-2/task-4.5-po-user-guide-update.md
+++ b/scrum.pmo/sprints/sprint-2/task-4.5-po-user-guide-update.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 4](./task-4.md)
 
 # Task 4.5 — PO: Update user guide for Docs column

--- a/scrum.pmo/sprints/sprint-2/task-4.md
+++ b/scrum.pmo/sprints/sprint-2/task-4.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 4: Replace Preview with Documentation Column and Extend TSCompletion for Docstrings

--- a/scrum.pmo/sprints/sprint-2/task-5.1-developer-enrich-jsdoc.md
+++ b/scrum.pmo/sprints/sprint-2/task-5.1-developer-enrich-jsdoc.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 5](./task-5.md)
 
 # Task 5.1 — Developer: Enrich class JSDoc across layer1/layer2 targets

--- a/scrum.pmo/sprints/sprint-2/task-5.2-tester-docs-column-tests.md
+++ b/scrum.pmo/sprints/sprint-2/task-5.2-tester-docs-column-tests.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md) | [Back to Task 5](./task-5.md)
 
 # Task 5.2 — Tester: Add scripted tests asserting Docs column shows JSDoc for TestClass

--- a/scrum.pmo/sprints/sprint-2/task-5.md
+++ b/scrum.pmo/sprints/sprint-2/task-5.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 5: Document Classes for TSCompletion and Add Ranger Doc Rendering Tests

--- a/scrum.pmo/sprints/sprint-2/task-6.md
+++ b/scrum.pmo/sprints/sprint-2/task-6.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 6: Make [Tab] behave like Right Arrow in TS Ranger

--- a/scrum.pmo/sprints/sprint-2/task-7.md
+++ b/scrum.pmo/sprints/sprint-2/task-7.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 7: Refactor typing model to prompt-line editing with cursor and shell-like completion

--- a/scrum.pmo/sprints/sprint-3/planning.md
+++ b/scrum.pmo/sprints/sprint-3/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprints](../)
 
 # Sprint 3 Planning

--- a/scrum.pmo/sprints/sprint-3/task-1.0-architect-gitscrumproject-spec.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.0-architect-gitscrumproject-spec.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.0: Architect - GitScrumProject Templating Spec (PUML + CLI UX)

--- a/scrum.pmo/sprints/sprint-3/task-1.1-developer-repo-scaffold.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.1-developer-repo-scaffold.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.1: Developer - Scaffold New Repo via CLI and GitHub

--- a/scrum.pmo/sprints/sprint-3/task-1.2-developer-submodule-runtime.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.2-developer-submodule-runtime.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.2: Developer - Submodule Integration and Runtime Overlay

--- a/scrum.pmo/sprints/sprint-3/task-1.3-devops-release-recovery.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.3-devops-release-recovery.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.3: DevOps/Developer - Release & Recovery Automation (Both Repos)

--- a/scrum.pmo/sprints/sprint-3/task-1.4-tester-e2e-tests.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.4-tester-e2e-tests.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.4: Tester - E2E and Unit Tests

--- a/scrum.pmo/sprints/sprint-3/task-1.5-po-user-guide.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.5-po-user-guide.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.5: PO - User Guide and Acceptance

--- a/scrum.pmo/sprints/sprint-3/task-1.6-docs-embed-svgs.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.6-docs-embed-svgs.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.6: Docs - Embed Generated SVG Diagrams in Markdown

--- a/scrum.pmo/sprints/sprint-3/task-1.7-po-plan-tla-sprint-1.md
+++ b/scrum.pmo/sprints/sprint-3/task-1.7-po-plan-tla-sprint-1.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Planning](./planning.md)
 
 # Task 1.7: PO — Plan Sprint 1 for TLA.scrum.pmo (wrapper project)

--- a/scrum.pmo/sprints/sprint-4/planning.md
+++ b/scrum.pmo/sprints/sprint-4/planning.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+Copyright (c) 2025 The Web4Articles Authors
+Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+Backlinks: /LICENSE , /AI-GPL.md
+Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+-->
+
 [Back to Sprints](../)
 
 # Sprint 4 Planning

--- a/src/domain/SimpleTaskStateMachine.ts
+++ b/src/domain/SimpleTaskStateMachine.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // SimpleTaskStateMachine.ts (migrated from UpDown/temp)
 // Minimal OOP state machine for task status
 

--- a/src/domain/TaskStateMachine.ts
+++ b/src/domain/TaskStateMachine.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // TaskStateMachine.ts (migrated from UpDown/temp)
 // OOP implementation for task state management in Web4Articles
 

--- a/src/puml/GitScrumProject_CLI_Architecture.puml
+++ b/src/puml/GitScrumProject_CLI_Architecture.puml
@@ -1,3 +1,9 @@
+' SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+' Copyright (c) 2025 The Web4Articles Authors
+' Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+' Backlinks: /LICENSE , /AI-GPL.md
+' Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 @startuml
 title GitScrumProject CLI OOP Architecture
 

--- a/src/puml/GitScrumProject_TemplateAndRelease.puml
+++ b/src/puml/GitScrumProject_TemplateAndRelease.puml
@@ -1,3 +1,9 @@
+' SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+' Copyright (c) 2025 The Web4Articles Authors
+' Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+' Backlinks: /LICENSE , /AI-GPL.md
+' Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 @startuml
 skinparam classAttributeIconSize 0
 title GitScrumProject Templating, Submodule, Release Architecture

--- a/src/sh/install.oosh-completion.sh
+++ b/src/sh/install.oosh-completion.sh
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+# Copyright (c) 2025 The Web4Articles Authors
+# Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+# Backlinks: /LICENSE , /AI-GPL.md
+# Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 #!/bin/bash
 # install.oosh-completion.sh: Register oosh-completion.sh as a completion function for oosh
 # Usage: source install.oosh-completion.sh

--- a/src/sh/oosh-completion.sh
+++ b/src/sh/oosh-completion.sh
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+# Copyright (c) 2025 The Web4Articles Authors
+# Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+# Backlinks: /LICENSE , /AI-GPL.md
+# Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 #!/usr/bin/env bash
 # oosh-completion.sh: prints completion candidates for the oosh CLI
 # Usage:

--- a/src/sh/tssh-completion.sh
+++ b/src/sh/tssh-completion.sh
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+# Copyright (c) 2025 The Web4Articles Authors
+# Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+# Backlinks: /LICENSE , /AI-GPL.md
+# Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+
 #!/bin/bash
 _tssh_completion() {
   COMPREPLY=($(COMP_CWORD=$COMP_CWORD COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" tssh --complete "${COMP_WORDS[@]}"))

--- a/src/ts/layer1/Logger.ts
+++ b/src/ts/layer1/Logger.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // Logger.ts: LOG_LEVEL-aware logger for CLI and app classes
 /**
  * Logger: Minimal, environment-aware logger for debugging and traceability.

--- a/src/ts/layer1/OOSH.ts
+++ b/src/ts/layer1/OOSH.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // Suppress all Node.js warnings (including experimental and deprecation)
 process.env.NODE_NO_WARNINGS = '1';
 // OOSH.ts: Strict OOP CLI class for Web4Articles

--- a/src/ts/layer1/ParameterParser.ts
+++ b/src/ts/layer1/ParameterParser.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 export class ParameterParser {
   private args: string[];
 

--- a/src/ts/layer1/TSsh.ts
+++ b/src/ts/layer1/TSsh.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 
 process.env.NODE_NO_WARNINGS = '1';
 import { Logger } from './Logger.ts';

--- a/src/ts/layer2/DefaultCLI.ts
+++ b/src/ts/layer2/DefaultCLI.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 
 import { Logger } from '../layer1/Logger.ts';
 

--- a/src/ts/layer2/GitScrumProject.ts
+++ b/src/ts/layer2/GitScrumProject.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { execSync } from 'child_process';
 import path from 'path';
 import * as fs from 'fs';

--- a/src/ts/layer2/LicenseTool.ts
+++ b/src/ts/layer2/LicenseTool.ts
@@ -1,0 +1,174 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export class LicenseTool {
+  static help(): void {
+    console.log(`LicenseTool CLI
+
+Usage:
+  tssh LicenseTool help                 Show help
+  tssh LicenseTool check                Check headers (non-zero exit if missing)
+  tssh LicenseTool apply                Apply/update headers in-place
+
+Notes:
+  - Supports comment-aware headers for: ts, tsx, js, jsx, md, puml, plantuml, sh, bash, yml, yaml
+  - Skips binary and non-commentable formats (e.g., json)
+  - Backlinks to ./LICENSE (AGPLv3) and ./AI-GPL.md
+`);
+  }
+
+  static async check(): Promise<void> {
+    const projectRoot = this.resolveProjectRoot();
+    const files = this.findTargetFiles(projectRoot);
+    const missing: string[] = [];
+    for (const file of files) {
+      const rel = path.relative(projectRoot, file);
+      const content = fs.readFileSync(file, 'utf8');
+      const style = this.getCommentStyle(file);
+      if (!style) continue;
+      if (!this.hasLicenseHeader(content, style)) {
+        missing.push(rel);
+      }
+    }
+    if (missing.length > 0) {
+      console.error('[LicenseTool] Missing/invalid headers in:');
+      for (const m of missing) console.error(' - ' + m);
+      process.exitCode = 2;
+    } else {
+      console.log('[LicenseTool] All checked files have headers.');
+    }
+  }
+
+  static async apply(): Promise<void> {
+    const projectRoot = this.resolveProjectRoot();
+    const files = this.findTargetFiles(projectRoot);
+    let updated = 0;
+    for (const file of files) {
+      const style = this.getCommentStyle(file);
+      if (!style) continue;
+      const original = fs.readFileSync(file, 'utf8');
+      const withHeader = this.ensureHeader(original, style, path.sep + 'AI-GPL.md', path.sep + 'LICENSE');
+      if (withHeader !== original) {
+        fs.writeFileSync(file, withHeader, 'utf8');
+        updated++;
+      }
+    }
+    console.log(`[LicenseTool] Updated ${updated} files.`);
+  }
+
+  private static resolveProjectRoot(): string {
+    let dir = process.cwd();
+    while (dir !== path.dirname(dir)) {
+      if (fs.existsSync(path.join(dir, 'package.json')) && fs.existsSync(path.join(dir, 'src', 'ts'))) {
+        return dir;
+      }
+      dir = path.dirname(dir);
+    }
+    return process.cwd();
+  }
+
+  private static findTargetFiles(root: string): string[] {
+    const results: string[] = [];
+    const ignoreDirs = new Set<string>(['.git', 'node_modules', 'dist', 'build', '.turbo', '.next', 'coverage']);
+    const visit = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name.startsWith('.DS_Store')) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (ignoreDirs.has(entry.name)) continue;
+          visit(full);
+        } else if (entry.isFile()) {
+          if (this.isTargetFile(full)) results.push(full);
+        }
+      }
+    };
+    visit(root);
+    return results;
+  }
+
+  private static isTargetFile(filePath: string): boolean {
+    const ext = path.extname(filePath).toLowerCase();
+    if (!ext) return false;
+    const supported = new Set(['.ts', '.tsx', '.js', '.jsx', '.md', '.puml', '.plantuml', '.sh', '.bash', '.yml', '.yaml']);
+    if (!supported.has(ext)) return false;
+    // Skip lockfiles and generated artifacts
+    const base = path.basename(filePath);
+    if (base === 'package-lock.json') return false;
+    return true;
+  }
+
+  private static getCommentStyle(filePath: string): { kind: 'block' | 'line' | 'md'; line: string; open?: string; close?: string } | null {
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext === '.ts' || ext === '.tsx' || ext === '.js' || ext === '.jsx') {
+      return { kind: 'block', line: ' * ', open: '/**', close: ' */' };
+    }
+    if (ext === '.md') {
+      return { kind: 'md', line: '', open: '<!--', close: '-->' };
+    }
+    if (ext === '.puml' || ext === '.plantuml') {
+      return { kind: 'line', line: "' " };
+    }
+    if (ext === '.sh' || ext === '.bash' || ext === '.yml' || ext === '.yaml') {
+      return { kind: 'line', line: '# ' };
+    }
+    return null;
+  }
+
+  private static buildHeader(style: { kind: 'block' | 'line' | 'md'; line: string; open?: string; close?: string }, relAIGPL: string, relAGPL: string): string {
+    const year = new Date().getUTCFullYear();
+    const lines = [
+      `SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum`,
+      `Copyright (c) ${year} The Web4Articles Authors`,
+      `Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)`,
+      `Backlinks: ${relAGPL} , ${relAIGPL}`,
+      'Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.',
+    ];
+    if (style.kind === 'block') {
+      return `${style.open}\n${lines.map(l => style.line + l).join('\n')}\n${style.close}\n\n`;
+    }
+    if (style.kind === 'line') {
+      return `${lines.map(l => style.line + l).join('\n')}\n\n`;
+    }
+    // md: prefer visible header since markdown supports HTML comments; keep it non-rendering
+    return `${style.open}\n${lines.join('\n')}\n${style.close}\n\n`;
+  }
+
+  private static hasLicenseHeader(content: string, style: { kind: 'block' | 'line' | 'md'; line: string; open?: string; close?: string }): boolean {
+    const marker1 = 'SPDX-License-Identifier:';
+    const marker2 = 'AI-GPL';
+    // Only check first 30 lines
+    const head = content.split(/\r?\n/).slice(0, 30).join('\n');
+    return head.includes(marker1) && head.includes(marker2);
+  }
+
+  private static ensureHeader(content: string, style: { kind: 'block' | 'line' | 'md'; line: string; open?: string; close?: string }, relAIGPL: string, relAGPL: string): string {
+    const header = this.buildHeader(style, relAIGPL, relAGPL);
+    if (this.hasLicenseHeader(content, style)) {
+      // Replace existing header block if present at top
+      const updated = content.replace(this.headerRegex(style), header.trimEnd() + '\n');
+      if (updated !== content) return updated;
+      return content; // Already ok
+    }
+    return header + content;
+  }
+
+  private static headerRegex(style: { kind: 'block' | 'line' | 'md'; line: string; open?: string; close?: string }): RegExp {
+    if (style.kind === 'block') {
+      // /** ... */ followed by optional blank lines
+      return /^\s*\/\*\*[\s\S]*?\*\/\s*\n?/;
+    }
+    if (style.kind === 'md') {
+      return /^\s*<!--[\s\S]*?-->\s*\n?/;
+    }
+    // line comments until blank line
+    return /^(?:[ \t]*[^\S\r\n]*[#'] .*\n)+\n?/;
+  }
+}

--- a/src/ts/layer2/RangerModel.ts
+++ b/src/ts/layer2/RangerModel.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { TSCompletion } from '../layer4/TSCompletion.ts';
 
 export class RangerModel {

--- a/src/ts/layer2/ResearchAgent.ts
+++ b/src/ts/layer2/ResearchAgent.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { Logger } from '../layer1/Logger.ts';
 
 /**

--- a/src/ts/layer2/TestClass.ts
+++ b/src/ts/layer2/TestClass.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // Minimal test class for completion validation
 /**
  * TestClass is a rich example used by TS Ranger to validate the Docs column.

--- a/src/ts/layer3/CLI.ts
+++ b/src/ts/layer3/CLI.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // CLI interface for OOP CLI composition
 export interface CLI {
   start(): void;

--- a/src/ts/layer3/Completion.ts
+++ b/src/ts/layer3/Completion.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // Completion interface for oosh CLI completion backend
 export interface Completion {
   complete(args: string[]): string[];

--- a/src/ts/layer3/Project.ts
+++ b/src/ts/layer3/Project.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 export interface Project {
   create(args: string[]): void;
 }

--- a/src/ts/layer4/Completion.ts
+++ b/src/ts/layer4/Completion.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // Completion interface for oosh CLI completion backend
 export interface Completion {
   complete(args: string[]): string[];

--- a/src/ts/layer4/RangerController.ts
+++ b/src/ts/layer4/RangerController.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { Logger } from '../layer1/Logger.ts';
 import { TSCompletion } from '../layer4/TSCompletion.ts';
 import { RangerModel } from '../layer2/RangerModel.ts';

--- a/src/ts/layer4/TSCompletion.ts
+++ b/src/ts/layer4/TSCompletion.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 // TypeScript Completion Backend for oosh CLI
 // Implements Completion interface for dynamic tab completion
 

--- a/src/ts/layer4/TSRanger.ts
+++ b/src/ts/layer4/TSRanger.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { RangerModel } from '../layer2/RangerModel.ts';
 import { RangerView } from '../layer5/RangerView.ts';
 import { RangerController } from './RangerController.ts';

--- a/src/ts/layer5/RangerView.ts
+++ b/src/ts/layer5/RangerView.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import os from 'node:os';
 import path from 'node:path';
 import { RangerModel } from '../layer2/RangerModel.ts';

--- a/test/TSCompletion.test.ts
+++ b/test/TSCompletion.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect, beforeAll } from 'vitest';
 
 

--- a/test/gitscrumproject.createTemplateRepo.test.ts
+++ b/test/gitscrumproject.createTemplateRepo.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { GitScrumProject } from '../src/ts/layer2/GitScrumProject.ts';
 

--- a/test/licenseTool.spec.ts
+++ b/test/licenseTool.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { LicenseTool } from '../src/ts/layer2/LicenseTool.ts';
+
+describe('LicenseTool.ensureHeader', () => {
+  it('inserts a block header for .ts', () => {
+    const style = (LicenseTool as any).getCommentStyle('/tmp/x.ts');
+    const out = (LicenseTool as any).ensureHeader('console.log("hi")\n', style, '/AI-GPL.md', '/LICENSE');
+    expect(out.startsWith('/**')).toBe(true);
+    expect(out.includes('SPDX-License-Identifier')).toBe(true);
+  });
+  it('inserts an HTML comment header for .md', () => {
+    const style = (LicenseTool as any).getCommentStyle('/tmp/x.md');
+    const out = (LicenseTool as any).ensureHeader('# Title\n', style, '/AI-GPL.md', '/LICENSE');
+    expect(out.startsWith('<!--')).toBe(true);
+    expect(out.includes('AI-GPL')).toBe(true);
+  });
+});

--- a/test/obash.integration.test.ts
+++ b/test/obash.integration.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'node:child_process';
 import path from 'node:path';

--- a/test/oosh-completion.shell.test.ts
+++ b/test/oosh-completion.shell.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
   it('completes default value for GitScrumProject create project using COMP_WORDS/COMP_CWORD', () => {
     // Simulate Bash completion environment
     const env = {

--- a/test/oosh-completion.test.ts
+++ b/test/oosh-completion.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';

--- a/test/tscompletion-cli.integration.test.ts
+++ b/test/tscompletion-cli.integration.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
 

--- a/test/tsranger.cursor.test.ts
+++ b/test/tsranger.cursor.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';

--- a/test/tsranger.docs.test.ts
+++ b/test/tsranger.docs.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';

--- a/test/tsranger.model.test.ts
+++ b/test/tsranger.model.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect, beforeAll } from 'vitest';
 import { TSCompletion } from '@src/ts/layer4/TSCompletion.ts';
 

--- a/test/tsranger.prompt.test.ts
+++ b/test/tsranger.prompt.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';

--- a/test/tsranger.promptline.behavior.test.ts
+++ b/test/tsranger.promptline.behavior.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';

--- a/test/tsranger.tab.test.ts
+++ b/test/tsranger.tab.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';

--- a/test/tssh-cli.integration.test.ts
+++ b/test/tssh-cli.integration.test.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 
 import fs from 'fs';
 import path from 'path';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,11 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only + AI-GPL-Addendum
+ * Copyright (c) 2025 The Web4Articles Authors
+ * Copyleft: See AGPLv3 (./LICENSE) and AI-GPL Addendum (./AI-GPL.md)
+ * Backlinks: /LICENSE , /AI-GPL.md
+ * Use of `scrum.pmo` roles/process docs with AI is subject to AI-GPL copyleft unless dual-licensed.
+ */
+
 
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'path';


### PR DESCRIPTION
Introduces AI-GPL addendum and automated license header enforcement for all project files, including `scrum.pmo` artifacts.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d9ddde6-a3ae-41ff-b131-7982797e09e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d9ddde6-a3ae-41ff-b131-7982797e09e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

